### PR TITLE
#CheckAccess-FixForDefaultSettings

### DIFF
--- a/GhostNetwork.Profiles.Api/Controllers/SecuritySettingsController.cs
+++ b/GhostNetwork.Profiles.Api/Controllers/SecuritySettingsController.cs
@@ -65,8 +65,8 @@ namespace GhostNetwork.Profiles.Api.Controllers
         {
             var result = await securitySettingsService.UpsertAsync(
                 userId,
-                new SecuritySettingsSection(model.Friends?.Access ?? Access.Everyone, model.Friends.CertainUsers ?? Enumerable.Empty<Guid>()),
-                new SecuritySettingsSection(model.Followers?.Access ?? Access.Everyone, model.Followers.CertainUsers ?? Enumerable.Empty<Guid>()),
+                new SecuritySettingsSection(model.Friends?.Access ?? Access.Everyone, model.Friends?.CertainUsers ?? Enumerable.Empty<Guid>()),
+                new SecuritySettingsSection(model.Followers?.Access ?? Access.Everyone, model.Followers?.CertainUsers ?? Enumerable.Empty<Guid>()),
                 new SecuritySettingsSection(model.Posts?.Access ?? Access.Everyone, model.Posts?.CertainUsers ?? Enumerable.Empty<Guid>()),
                 new SecuritySettingsSection(model.Comments?.Access ?? Access.Everyone, model.Comments?.CertainUsers ?? Enumerable.Empty<Guid>()),
                 new SecuritySettingsSection(model.ProfilePhoto?.Access ?? Access.Everyone, model.ProfilePhoto?.CertainUsers ?? Enumerable.Empty<Guid>()));

--- a/GhostNetwork.Profiles.Api/Controllers/SecuritySettingsController.cs
+++ b/GhostNetwork.Profiles.Api/Controllers/SecuritySettingsController.cs
@@ -65,11 +65,11 @@ namespace GhostNetwork.Profiles.Api.Controllers
         {
             var result = await securitySettingsService.UpsertAsync(
                 userId,
-                new SecuritySettingsSection(model.Friends.Access, model.Friends.CertainUsers ?? Enumerable.Empty<Guid>()),
-                new SecuritySettingsSection(model.Followers.Access, model.Followers.CertainUsers ?? Enumerable.Empty<Guid>()),
-                new SecuritySettingsSection(model.Posts.Access, model.Posts.CertainUsers ?? Enumerable.Empty<Guid>()),
-                new SecuritySettingsSection(model.Comments.Access, model.Comments.CertainUsers ?? Enumerable.Empty<Guid>()),
-                new SecuritySettingsSection(model.ProfilePhoto.Access, model.ProfilePhoto.CertainUsers ?? Enumerable.Empty<Guid>()));
+                new SecuritySettingsSection(model.Friends?.Access ?? Access.Everyone, model.Friends.CertainUsers ?? Enumerable.Empty<Guid>()),
+                new SecuritySettingsSection(model.Followers?.Access ?? Access.Everyone, model.Followers.CertainUsers ?? Enumerable.Empty<Guid>()),
+                new SecuritySettingsSection(model.Posts?.Access ?? Access.Everyone, model.Posts?.CertainUsers ?? Enumerable.Empty<Guid>()),
+                new SecuritySettingsSection(model.Comments?.Access ?? Access.Everyone, model.Comments?.CertainUsers ?? Enumerable.Empty<Guid>()),
+                new SecuritySettingsSection(model.ProfilePhoto?.Access ?? Access.Everyone, model.ProfilePhoto?.CertainUsers ?? Enumerable.Empty<Guid>()));
 
             if (result.Successed)
             {

--- a/GhostNetwork.Profiles.Api/GhostNetwork.Profiles.Api.csproj
+++ b/GhostNetwork.Profiles.Api/GhostNetwork.Profiles.Api.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GhostNetwork.Profiles.Api/Models/SecuritySettingUpdateViewModel.cs
+++ b/GhostNetwork.Profiles.Api/Models/SecuritySettingUpdateViewModel.cs
@@ -1,22 +1,15 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace GhostNetwork.Profiles.Api.Models
+﻿namespace GhostNetwork.Profiles.Api.Models
 {
     public class SecuritySettingUpdateViewModel
     {
-        [Required]
         public SecuritySettingsSectionInputModel Posts { get; set; }
 
-        [Required]
         public SecuritySettingsSectionInputModel Friends { get;  set; }
 
-        [Required]
         public SecuritySettingsSectionInputModel Comments { get; set; }
 
-        [Required]
         public SecuritySettingsSectionInputModel ProfilePhoto { get; set; }
 
-        [Required]
         public SecuritySettingsSectionInputModel Followers { get; set; }
     }
 }

--- a/GhostNetwork.Profiles.Api/Startup.cs
+++ b/GhostNetwork.Profiles.Api/Startup.cs
@@ -101,7 +101,7 @@ namespace GhostNetwork.Profiles.Api
             {
                 app
                     .UseSwagger()
-                    .UseSwaggerUI(config => { config.SwaggerEndpoint("/swagger/v1/swagger.json", "Profiles Api V1"); });
+                    .UseSwaggerUI(config => { config.SwaggerEndpoint("/swagger/api/swagger.json", "Profiles Api V1"); });
 
                 app.UseCors(builder => builder.AllowAnyHeader()
                     .AllowAnyMethod()

--- a/GhostNetwork.Profiles.Api/Startup.cs
+++ b/GhostNetwork.Profiles.Api/Startup.cs
@@ -39,7 +39,7 @@ namespace GhostNetwork.Profiles.Api
                 options.SwaggerDoc("api", new OpenApiInfo
                 {
                     Title = "GhostNetwork.Profiles",
-                    Version = "1.3.5"
+                    Version = "1.3.6"
                 });
 
                 options.OperationFilter<OperationIdFilter>();

--- a/Infrastructure/GhostNetwork.Profiles.MongoDb/SecuritySettingsStorage.cs
+++ b/Infrastructure/GhostNetwork.Profiles.MongoDb/SecuritySettingsStorage.cs
@@ -42,7 +42,12 @@ namespace GhostNetwork.Profiles.MongoDb
                 .Project<SecuritySettingsSectionEntity>(project)
                 .FirstOrDefaultAsync();
 
-            return new SecuritySettingsSection(section.Access, null!).Access;
+            if (section == null)
+            {
+                return Access.Everyone;
+            }
+
+            return section.Access;
         }
 
         public async Task<bool> ContainsInCertainUsersAsync(Guid userId, Guid ofUserId, string sectionName)

--- a/tests/GhostNetwork.Profiles.ApiTests/GhostNetwork.Profiles.ApiTests.csproj
+++ b/tests/GhostNetwork.Profiles.ApiTests/GhostNetwork.Profiles.ApiTests.csproj
@@ -12,9 +12,9 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.11" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
       <PackageReference Include="Moq" Version="4.16.1" />
-      <PackageReference Include="NUnit" Version="3.13.2" />
+      <PackageReference Include="NUnit" Version="3.13.3" />
       <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     </ItemGroup>
 

--- a/tests/GhostNetwork.Profiles.Tests/GhostNetwork.Profiles.Tests.csproj
+++ b/tests/GhostNetwork.Profiles.Tests/GhostNetwork.Profiles.Tests.csproj
@@ -6,9 +6,9 @@
 
     <ItemGroup>
         <PackageReference Include="Moq" Version="4.16.1" />
-        <PackageReference Include="nunit" Version="3.12.0" />
+        <PackageReference Include="nunit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     </ItemGroup>
   
     <ItemGroup>


### PR DESCRIPTION
# Description

Fix selecting access level for section if record with security settings doesn't exists in DB
Remove 'Required' attribute from SecuritySettingUpdateViewModel 
Update some packages that were marked as 'Consolidate'
Fix opening swagger UI

Select single relevant option.

- [ ] Bug fix (non-breaking change which fixes an issue)